### PR TITLE
Made macro to replace vfs.h with mount.h for Mac

### DIFF
--- a/src/UT/DISKINFO.cpp
+++ b/src/UT/DISKINFO.cpp
@@ -17,7 +17,11 @@
 #     include <sys/statvfs.h>
 #  else
 #     include <sys/stat.h>
-#     include <sys/vfs.h>
+#     ifdef __APPLE__
+#        include<sys/mount.h>
+#     else
+#        include<sys/vfs.h>
+#     endif
 #  endif
 
 #  include <sys/types.h>

--- a/src/UT/INQSIZE.cpp
+++ b/src/UT/INQSIZE.cpp
@@ -16,7 +16,11 @@
 #  include<stdio.h>
 #  include<sys/time.h>
 #  include<sys/types.h>
-#  include<sys/vfs.h>
+#  ifdef __APPLE__
+#     include<sys/mount.h>
+#  else
+#     include<sys/vfs.h>
+#  endif
 #  include<fcntl.h>
 #  include<sys/stat.h>
 #  include<errno.h>

--- a/src/UT/INQTID.cpp
+++ b/src/UT/INQTID.cpp
@@ -15,7 +15,11 @@
 #  include<stdio.h>
 #  include<sys/time.h>
 #  include<sys/types.h>
-#  include<sys/vfs.h>
+#  ifdef __APPLE__
+#    include<sys/mount.h>
+#  else
+#    include<sys/vfs.h>
+#  endif
 #  include<fcntl.h>
 #  include<sys/stat.h>
 #  include<errno.h>


### PR DESCRIPTION
Replaced

     #include <sys/vsf.h> 
with 

     #  ifdef __APPLE__
     #    include<sys/mount.h>
     #  else
     #    include<sys/vfs.h>
     #  endif

Regarding issue #12