### PR TITLE
Fix missing definition of UT_INT64 for APPLE

### DIFF
--- a/src/UT/fyut.h
+++ b/src/UT/fyut.h
@@ -57,6 +57,11 @@
 
 #else
           /* For UNIX */
+#  ifdef __APPLE__
+#    include <stdint.h>
+#    define UT_INT64 int64_t
+#  endif
+
 #  ifdef LINUX /* specifically the LINUX */
 #    include <stdint.h>
 #    include <inttypes.h>


### PR DESCRIPTION
Otherwise, the following, when compiling on Mac OS X 10.11 with `clang`:
```cpp
#include "fyba.h"
int main() {
  SK_EntPnt_FYBA char *LC_InqVer(void);
  return 0;
}
```
errors with...
```
/usr/local/Cellar/fyba/4.1.1/include/fyba/fyba.h:760:4: error: unknown type name 'UT_INT64'
   UT_INT64 n64AktPos;        // Aktuell posisjon for sekv. skriv / les
   ^
/usr/local/Cellar/fyba/4.1.1/include/fyba/fyba.h:761:2: error: unknown type name 'UT_INT64'
        UT_INT64 n64NesteLedigRbPos; // Neste ledige posisjon i buffer-filen
        ^
/usr/local/Cellar/fyba/4.1.1/include/fyba/fyba.h:804:4: error: unknown type name 'UT_INT64'
   UT_INT64    n64FilPosRb; // Aktuell posisjon i buffer-filen 
   ^
/usr/local/Cellar/fyba/4.1.1/include/fyba/fyba.h:1091:53: error: unknown type name 'UT_INT64'
SK_EntPnt_FYBA short HO_TestSOSI(const char *pszFil,UT_INT64 *sluttpos);
```