### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @ulvtro
+/.security/ @ulvtro

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: FYSAK
 repo_types: [Deprecated,Library]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "fysak"
   system: "fysak"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_fyba"
-  title: "Security Champion fyba"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "ulvtro"
-  children:
-  - "resource:fyba"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "fyba"
-  links:
-  - url: "https://github.com/kartverket/fyba"
-    title: "fyba på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_fyba"
-  dependencyOf:
-  - "component:fyba"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml